### PR TITLE
Add platformio configuration file.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,21 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+


### PR DESCRIPTION
This change add a platformio configuration.

Platformio is a build framework that is able to compile and upload Arduino programs. Settings like which target you run (esp8266), which board (e.g. wemos d1 mini) and which libraries you use (and their versions) are specified in a simple text file. This enables you to build the firmware from the command line without having to worry if you selected the correct target board (with the correct settings) in the Arduino IDE and without having to remember which library you use.

On Debian Linux you can install it with
  sudo apt-get install python-pip
  sudo pip install platformio

Then you can compile and upload the binary using
  pio run -t upload

It will download (and cache locally) the xtensa toolchain, arduino libraries, compile the source and upload it to your board.